### PR TITLE
evaluating configurable references with kwargs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ train_fn.optimizer_cls = @tf.train.GradientDescentOptimizer
 
 Sometimes it is necessary to pass the result of calling a specific function or
 class constructor. Gin supports "evaluating" configurable references via the
-`@name()` syntax. For example, say we wanted to use the class form of `DNN` from
+`@name(**kwargs)` syntax. For example, say we wanted to use the class form of `DNN` from
 above (which implements `__call__` to "behave" like a function) in the following
 Python code:
 
@@ -183,6 +183,13 @@ We could pass an instance of the `DNN` class to the `network_fn` parameter:
 ```python
 # Inside "config.gin"
 build_model.network_fn = @DNN()
+```
+
+or 
+
+```python
+# Inside "config.gin"
+build_model.network_fin=@DNN(num_outputs=15)
 ```
 
 To use evaluated references, all of the referenced function or class's
@@ -330,7 +337,7 @@ Gin is still in alpha development and some corner-case behaviors may be
 changed in backwards-incompatible ways. We recommend the following best
 practices:
 
--   Minimize use of evaluated configurable references (`@name()`), especially
+-   Minimize use of evaluated configurable references (`@name(**kwargs)`), especially
     when combined with macros (where the fact that the value is not cached may
     be surprising to new users).
 -   Avoid nesting of scopes (i.e., `scope1/scope2/function_name`). While

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ or
 
 ```python
 # Inside "config.gin"
-build_model.network_fin=@DNN(num_outputs=15)
+build_model.network_fn=@DNN(num_outputs=15)
 ```
 
 To use evaluated references, all of the referenced function or class's

--- a/gin/config_parser.py
+++ b/gin/config_parser.py
@@ -47,7 +47,7 @@ class ParserDelegate(object):
   __metaclass__ = abc.ABCMeta
 
   @abc.abstractmethod
-  def configurable_reference(self, scoped_configurable_name, evaluate):
+  def configurable_reference(self, scoped_configurable_name, evaluate, kwargs):
     """Called to construct an object representing a configurable reference.
 
     Args:
@@ -422,18 +422,31 @@ class ConfigParser(object):
     location = self._current_location()
     self._advance_one_token()
     scoped_name = self._parse_selector(allow_periods_in_scope=True)
-
     evaluate = False
+    kwargs = dict()
     if self._current_token.value == '(':
-      evaluate = True
       self._advance()
-      if self._current_token.value != ')':
-        self._raise_syntax_error("Expected ')'.")
+      evaluate = True
+      while self._current_token.value != ')':
+        if self._current_token.kind != tokenize.NAME:
+          raise self._raise_syntax_error('Unexpected token.')
+        arg_name = self._current_token.value
+        self._advance_one_token()
+        if self._current_token.value != '=':
+          raise self._raise_syntax_error("Expected '='.")
+        self._advance()
+        arg_value = self.parse_value()
+        kwargs[arg_name] = arg_value
+        if self._current_token.value == ',':
+          self._advance()
+          continue
+        if self._current_token.value != ')':
+          self._raise_syntax_error("Expected ')'.")
       self._advance_one_token()
     self._skip_whitespace_and_comments()
 
     with utils.try_with_location(location):
-      reference = self._delegate.configurable_reference(scoped_name, evaluate)
+      reference = self._delegate.configurable_reference(scoped_name, evaluate, kwargs)
 
     return True, reference
 

--- a/tests/config_parser_test.py
+++ b/tests/config_parser_test.py
@@ -88,7 +88,7 @@ class _TestParserDelegate(config_parser.ParserDelegate):
   def __init__(self, raise_error=False):
     self._raise_error = raise_error
 
-  def configurable_reference(self, scoped_name, evaluate):
+  def configurable_reference(self, scoped_name, evaluate, kwargs):
     if self._raise_error:
       raise ValueError('Unknown configurable.')
     return _TestConfigurableReference(scoped_name, evaluate)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -699,7 +699,7 @@ class ConfigTest(absltest.TestCase):
     instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
     self.assertEqual(instance.implement_me(), 'bananaphone')
 
-  def testConfigurableWithFunctioncall(self):
+  def testConfigurableEvaluateWithKeywordargs(self):
     config_str = """   
           M = 'macro'       
           ConfigurableClass.kwarg1 = @configurable2(non_kwarg='statler')
@@ -709,6 +709,18 @@ class ConfigTest(absltest.TestCase):
     instance = ConfigurableClass()
     self.assertEqual(instance.kwarg1, ('statler', None))
     self.assertEqual(instance.kwarg2, ('macro', 'waldorf'))
+
+    config_str = """   
+          M = 'macro' 
+          ConfigurableClass.kwarg1 = @configurable2(non_kwarg=(1,2,3))                
+          ConfigurableClass.kwarg2 = @configurable2(non_kwarg=[%M, 1, {'name': 'statler'}])
+    """
+    config.clear_config()
+    config.parse_config(config_str)
+    instance = ConfigurableClass()
+    self.assertEqual(instance.kwarg1, ((1,2,3), None))
+    self.assertEqual(instance.kwarg2, (['macro', 1, {'name': 'statler'}], None))
+
 
   def testExternalConfigurableClass(self):
     config_str = """

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -699,6 +699,17 @@ class ConfigTest(absltest.TestCase):
     instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
     self.assertEqual(instance.implement_me(), 'bananaphone')
 
+  def testConfigurableWithFunctioncall(self):
+    config_str = """   
+          M = 'macro'       
+          ConfigurableClass.kwarg1 = @configurable2(non_kwarg='statler')
+          ConfigurableClass.kwarg2 = @configurable2(non_kwarg=%M, kwarg1='waldorf')
+    """
+    config.parse_config(config_str)
+    instance = ConfigurableClass()
+    self.assertEqual(instance.kwarg1, ('statler', None))
+    self.assertEqual(instance.kwarg2, ('macro', 'waldorf'))
+
   def testExternalConfigurableClass(self):
     config_str = """
       ConfigurableClass.kwarg1 = @ExternalConfigurable


### PR DESCRIPTION
Sometimes it is necessary to pass the result of calling a specific function or class constructor. Gin supports "evaluating" configurable references via the @name() syntax, but do not support passing 
keyword args ,   it's not flexible

For example,  say we wanted to use the result of calling `test_func` 

```python
@gin.configurable
def test_func(a , b)
    ...
```
we should config as
```
scope/test_func.a='a'
scope/test_func.b='b'
ref=scope/test_func()
```

with this pr,  it can be simplified as 
```
ref=scope/test_func(a='a', b='b')
```

NOTE:  sequence args is not supported
BTW: have sent a pr to the official version , but no feedback yet .

