### PR TITLE
ordinary reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Note that no other changes are required to the Python code, beyond adding the
 
 [multiple files]: https://github.com/google/gin-config/tree/master/docs/index.md#experiments-with-multiple-gin-files-and-extra-command-line-bindings
 
-### 3. Passing functions, classes, and instances ("configurable references")
+### 3. Passing configurable functions, classes, and instances ("configurable references")
 
 In addition to accepting Python literal values, Gin also supports passing other
 Gin-configurable functions or classes. In the example above, we might want to
@@ -168,7 +168,7 @@ train_fn.optimizer_cls = @tf.train.GradientDescentOptimizer
 
 Sometimes it is necessary to pass the result of calling a specific function or
 class constructor. Gin supports "evaluating" configurable references via the
-`@name(**kwargs)` syntax. For example, say we wanted to use the class form of `DNN` from
+`@name(*args, **kwargs)` syntax. For example, say we wanted to use the class form of `DNN` from
 above (which implements `__call__` to "behave" like a function) in the following
 Python code:
 
@@ -202,7 +202,64 @@ call to `build_model`.
 
 [external configurables]: https://github.com/google/gin-config/tree/master/docs/index.md#making-existing-classes-or-functions-configurable
 
-### 4. Configuring the same function in different ways ("scopes")
+
+### 4. Passing ordinary functions, classes, and instances ("ordinary references")
+
+In addition to accepting Python literal values, Gin also supports passing other
+functions or classes. In the example above, we might want to change the `activation_fn` 
+parameter. Say `tf.nn.tanh`, we can pass it to `activation_fn` by referring to it as 
+`tanh` (or `tf.nn.tanh`):
+
+```python
+# Inside "config.gin"
+dnn.activation_fn = tf.nn.tanh
+```
+
+Sometimes it is necessary to pass the result of calling a specific function or
+class constructor. Gin supports "evaluating" ordinary references via the
+`name(*args, **kwargs)` syntax. For example, say we wanted to use the class form of `DNN` from
+above (which implements `__call__` to "behave" like a function) in the following
+Python code:
+
+```python
+def build_model(inputs, network_fn, ...):
+  logits = network_fn(inputs)
+  ...
+```
+
+We could pass an instance of the `DNN` class to the `network_fn` parameter:
+
+```python
+# Inside "config.gin"
+build_model.network_fn = DNN()
+```
+
+or 
+
+```python
+# Inside "config.gin"
+build_model.network_fn=DNN(num_outputs=15)
+```
+
+
+It should be noted, sometimes we want to reference to a third_party or builtin functions
+and it's not reasonable to  register them all as configurable reference by gin.external_configurable 
+explict in advance. And the flowing are difference between in `Configurable reference` and `Ordinary reference` 
+
+* `Configurable reference` are functions and classes that decorated by `@gin.configurable` or registered by 
+`gin.external_configurable` explict. It's a subset of `Ordinary reference`
+
+* `Configurable reference` can be configured with default values by Gin
+
+* When refer to a `Configurable reference`,  should make sure that the reference is 
+registered in `gin` (imported) before parsing the config
+
+* When refer to an `Ordinary reference`, should make sure that the reference is defined and can visited
+when the reference is actually evaluated
+
+
+
+### 5. Configuring the same function in different ways ("scopes")
 
 What happens if we want to configure the same function in different ways? For
 instance, imagine we're building a GAN, where we might have a "generator"
@@ -241,7 +298,7 @@ Any parameters set on the "root" (unscoped) function name are inherited by
 scoped variants (unless explicitly overridden), so in the above example both the
 generator and the discriminator use the `tf.nn.tanh` activation function.
 
-### 5. Full hierarchical configuration
+### 6. Full hierarchical configuration
 
 The greatest degree of flexibility and configurability in a project is achieved
 by writing small modular functions and "wiring them up" hierarchically via
@@ -337,7 +394,7 @@ Gin is still in alpha development and some corner-case behaviors may be
 changed in backwards-incompatible ways. We recommend the following best
 practices:
 
--   Minimize use of evaluated configurable references (`@name(**kwargs)`), especially
+-   Minimize use of evaluated configurable references (`@name(*args, **kwargs)`), especially
     when combined with macros (where the fact that the value is not cached may
     be surprising to new users).
 -   Avoid nesting of scopes (i.e., `scope1/scope2/function_name`). While

--- a/README.md
+++ b/README.md
@@ -244,15 +244,15 @@ build_model.network_fn=DNN(num_outputs=15)
 
 It should be noted, sometimes we want to reference to a third_party or builtin functions
 and it's not reasonable to register them all as configurable reference by gin.external_configurable 
-explict in advance. The following are difference between in `Configurable reference` and `Ordinary reference` 
+explict in advance. The following are the differences between in `Configurable reference` and `Ordinary reference`:
 
 * `Configurable reference` are functions and classes that decorated by `@gin.configurable` or registered by 
-`gin.external_configurable` explict. It's a subset of `Ordinary reference`.
+`gin.external_configurable` explictly. It's a subset of `Ordinary reference`.
 
 * `Configurable reference` can be configured with default values by Gin.
 
 * When refer to a `Configurable reference`,  you should make sure that the reference is 
-registered to `gin` (imported) before parsing the config.
+registered to `gin` (decorated using @gin.configurable and imported) before parsing the config.
 
 * When refer to an `Ordinary reference`, you should make sure that the reference is defined and can be accessed
 when the reference is actually evaluated. But a good practice is to avoid referencing local variables. 

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ dnn.activation_fn = tf.nn.tanh
 
 Sometimes it is necessary to pass the result of calling a specific function or
 class constructor. Gin supports "evaluating" ordinary references via the
-`name(*args, **kwargs)` syntax. For example, say we wanted to use the class form of `DNN` from
-above (which implements `__call__` to "behave" like a function) in the following
+`name(*args, **kwargs)` syntax. For example, say we want to use the class form of `DNN` from
+the above (which implements `__call__` to "behave" like a function) in the following
 Python code:
 
 ```python
@@ -243,19 +243,20 @@ build_model.network_fn=DNN(num_outputs=15)
 
 
 It should be noted, sometimes we want to reference to a third_party or builtin functions
-and it's not reasonable to  register them all as configurable reference by gin.external_configurable 
-explict in advance. And the flowing are difference between in `Configurable reference` and `Ordinary reference` 
+and it's not reasonable to register them all as configurable reference by gin.external_configurable 
+explict in advance. The following are difference between in `Configurable reference` and `Ordinary reference` 
 
 * `Configurable reference` are functions and classes that decorated by `@gin.configurable` or registered by 
-`gin.external_configurable` explict. It's a subset of `Ordinary reference`
+`gin.external_configurable` explict. It's a subset of `Ordinary reference`.
 
-* `Configurable reference` can be configured with default values by Gin
+* `Configurable reference` can be configured with default values by Gin.
 
-* When refer to a `Configurable reference`,  should make sure that the reference is 
-registered in `gin` (imported) before parsing the config
+* When refer to a `Configurable reference`,  you should make sure that the reference is 
+registered to `gin` (imported) before parsing the config.
 
-* When refer to an `Ordinary reference`, should make sure that the reference is defined and can visited
-when the reference is actually evaluated
+* When refer to an `Ordinary reference`, you should make sure that the reference is defined and can be accessed
+when the reference is actually evaluated. But a good practice is to avoid referencing local variables. 
+For the purpose of readability and stability, you should only use `Ordinary reference` for glabally accessible identifiers.
 
 
 

--- a/gin/config_parser.py
+++ b/gin/config_parser.py
@@ -453,7 +453,7 @@ class ConfigParser(object):
     return True, reference
 
   def _maybe_parse_identifier_reference(self):
-    """Try to parse a identifier reference([package.package.]var_or_fn_or_cls_name[()])"""
+    """Try to parse a identifier reference([package.package.]var_or_fn_or_cls_name"""
     location = self._current_location()
 
     if self._current_token.kind != tokenize.NAME:

--- a/tests/config_parser_test.py
+++ b/tests/config_parser_test.py
@@ -88,7 +88,7 @@ class _TestParserDelegate(config_parser.ParserDelegate):
   def __init__(self, raise_error=False):
     self._raise_error = raise_error
 
-  def configurable_reference(self, scoped_name, evaluate, kwargs):
+  def configurable_reference(self, scoped_name, evaluate, args, kwargs):
     if self._raise_error:
       raise ValueError('Unknown configurable.')
     return _TestConfigurableReference(scoped_name, evaluate)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -699,6 +699,30 @@ class ConfigTest(absltest.TestCase):
     instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
     self.assertEqual(instance.implement_me(), 'bananaphone')
 
+
+  def testLocalVariableReference(self):
+    config_str = """
+          configurable2.non_kwarg = a
+    """
+    config.parse_config(config_str)
+
+    a = 1
+    instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
+    self.assertEqual(instance, a)
+
+    a = 2
+    instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
+    self.assertEqual(instance, a)
+
+  def testUnregisteredFunction(self):
+    config_str = """
+             configurable2.non_kwarg = numpy.abs
+    """
+    config.parse_config(config_str)
+    import numpy
+    instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
+    self.assertEqual(instance, numpy.abs)
+
   def testExternalConfigurableClass(self):
     config_str = """
       ConfigurableClass.kwarg1 = @ExternalConfigurable

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -722,6 +722,23 @@ class ConfigTest(absltest.TestCase):
     instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
     self.assertEqual(instance, numpy.abs)
 
+  def testUnregisteredFunctionEvaluate(self):
+    def test_fun(non_kwarg, kwarg1=None, kwarg2=None, kwarg3=None):
+      return non_kwarg, kwarg1, kwarg2, kwarg3
+    config_str = """
+            configurable2.non_kwarg = test_fun(0, 1, kwarg3=test_fun(0, 1, 2, 3)) 
+    """
+    config.parse_config(config_str)
+    instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
+    self.assertEqual(instance, (0, 1, None, (0, 1, 2, 3)))
+
+    config_str = """
+            configurable2.non_kwarg = eval('lambda x, y: x+y')
+    """
+    config.parse_config(config_str)
+    instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
+    self.assertEqual(instance(2, 3), 5)
+
 
   def testConfigurableEvaluateWithKeywordargs(self):
     config_str = """   


### PR DESCRIPTION
Now, gin config support `configurable reference`, `macro` , `basic type (str, bool, number)` or `nested of them`  as value .  When we want to reference to a third_party `class` , `function` or `variable` ..., we need register them as configurable reference by `gin.external_configurable`  explictly in advance, see `gin.tf` and `gin.torch` , it's not flexiable

with this pr , we can meet the following tests
```python
  def testLocalVariableReference(self):
    config_str = """
          configurable2.non_kwarg = a
    """
    config.parse_config(config_str)

    a = 1
    instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
    self.assertEqual(instance, a)

    a = 2
    instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
    self.assertEqual(instance, a)

  def testUnregisteredFunction(self):
    config_str = """
             configurable2.non_kwarg = numpy.abs
    """
    config.parse_config(config_str)
    import numpy
    instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
    self.assertEqual(instance, numpy.abs)
```

BTW: have sent a pr to official version , no feedback yet
