### PR TITLE
Make identifier are evaluated from modules imported by gin

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ We could pass an instance of the `DNN` class to the `network_fn` parameter:
 build_model.network_fn = @DNN()
 ```
 
-or 
+or
 
 ```python
 # Inside "config.gin"
@@ -206,8 +206,8 @@ call to `build_model`.
 ### 4. Passing ordinary functions, classes, and instances ("ordinary references")
 
 In addition to accepting Python literal values, Gin also supports passing other
-functions or classes. In the example above, we might want to change the `activation_fn` 
-parameter. Say `tf.nn.tanh`, we can pass it to `activation_fn` by referring to it as 
+functions or classes. In the example above, we might want to change the `activation_fn`
+parameter. Say `tf.nn.tanh`, we can pass it to `activation_fn` by referring to it as
 `tanh` (or `tf.nn.tanh`):
 
 ```python
@@ -234,30 +234,27 @@ We could pass an instance of the `DNN` class to the `network_fn` parameter:
 build_model.network_fn = DNN()
 ```
 
-or 
+or
 
 ```python
 # Inside "config.gin"
 build_model.network_fn=DNN(num_outputs=15)
 ```
 
-
 It should be noted, sometimes we want to reference to a third_party or builtin functions
-and it's not reasonable to register them all as configurable reference by gin.external_configurable 
+and it's not reasonable to register them all as configurable reference by gin.external_configurable
 explict in advance. The following are the differences between in `Configurable reference` and `Ordinary reference`:
 
-* `Configurable reference` are functions and classes that decorated by `@gin.configurable` or registered by 
+* `Configurable reference` are functions and classes that decorated by `@gin.configurable` or registered by
 `gin.external_configurable` explictly. It's a subset of `Ordinary reference`.
 
 * `Configurable reference` can be configured with default values by Gin.
 
-* When refer to a `Configurable reference`,  you should make sure that the reference is 
+* When refer to a `Configurable reference`,  you should make sure that the reference is
 registered to `gin` (decorated using @gin.configurable and imported) before parsing the config.
 
 * When refer to an `Ordinary reference`, you should make sure that the reference is defined and can be accessed
-when the reference is actually evaluated. But a good practice is to avoid referencing local variables. 
-For the purpose of readability and stability, you should only use `Ordinary reference` for glabally accessible identifiers.
-
+from modules imported by Gin (through import statement).
 
 
 ### 5. Configuring the same function in different ways ("scopes")

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -699,38 +699,23 @@ class ConfigTest(absltest.TestCase):
     instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
     self.assertEqual(instance.implement_me(), 'bananaphone')
 
-  def testLocalVariableReference(self):
-    config_str = """
-          configurable2.non_kwarg = a
-    """
-    config.parse_config(config_str)
-
-    a = 1
-    instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
-    self.assertEqual(instance, a)
-
-    a = 2
-    instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
-    self.assertEqual(instance, a)
-
   def testUnregisteredFunction(self):
     config_str = """
+             import numpy
              configurable2.non_kwarg = numpy.abs
     """
     config.parse_config(config_str)
-    import numpy
     instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
+    import numpy
     self.assertEqual(instance, numpy.abs)
 
   def testUnregisteredFunctionEvaluate(self):
-    def test_fun(non_kwarg, kwarg1=None, kwarg2=None, kwarg3=None):
-      return non_kwarg, kwarg1, kwarg2, kwarg3
     config_str = """
-            configurable2.non_kwarg = test_fun(0, 1, kwarg3=test_fun(0, 1, 2, 3)) 
+            configurable2.non_kwarg = dict(a=0, b=1, c=2, d=3)
     """
     config.parse_config(config_str)
     instance, _ = configurable2()  # pylint: disable=no-value-for-parameter
-    self.assertEqual(instance, (0, 1, None, (0, 1, 2, 3)))
+    self.assertEqual(instance, dict(a=0, b=1, c=2, d=3))
 
     config_str = """
             configurable2.non_kwarg = eval('lambda x, y: x+y')
@@ -741,8 +726,8 @@ class ConfigTest(absltest.TestCase):
 
 
   def testConfigurableEvaluateWithKeywordargs(self):
-    config_str = """   
-          M = 'macro'       
+    config_str = """
+          M = 'macro'
           ConfigurableClass.kwarg1 = @configurable2(non_kwarg='statler')
           ConfigurableClass.kwarg2 = @configurable2(non_kwarg=%M, kwarg1='waldorf')
     """
@@ -751,9 +736,9 @@ class ConfigTest(absltest.TestCase):
     self.assertEqual(instance.kwarg1, ('statler', None))
     self.assertEqual(instance.kwarg2, ('macro', 'waldorf'))
 
-    config_str = """   
-          M = 'macro' 
-          ConfigurableClass.kwarg1 = @configurable2(non_kwarg=(1,2,3))                
+    config_str = """
+          M = 'macro'
+          ConfigurableClass.kwarg1 = @configurable2(non_kwarg=(1,2,3))
           ConfigurableClass.kwarg2 = @configurable2(non_kwarg=[%M, 1, {'name': 'statler'}])
     """
     config.clear_config()


### PR DESCRIPTION
Previously, it's evaluated using the calling context in python, which is hard to figure out.
For example, suppose I want to use alf.TensorSpecs in gin, previously I have to ensure that
somewhere in the python code, when that gin statement is used, alf is imported. It is very
hard to ensure this. This change makes sure that the ordinary references are valid based
on the modules imported within gin configuration.